### PR TITLE
Prevent rogue apostrophes from causing mayhem.

### DIFF
--- a/growl.pl
+++ b/growl.pl
@@ -35,11 +35,13 @@ sub receiving_im_msg_cb {
     Purple::Debug::info("growl", '================================================');
     Purple::Debug::info("growl", Dumper $account->get_protocol_id() );
     $msg =~ s/<[^>]+>//g;
+    $msg =~ s/"/''/g;
     next if $msg =~ /\?OTR/;
     Purple::Debug::info("growl", Dumper $msg);
     my $buddy = Purple::Find::buddy($account, $who);
     $display_name = $buddy->get_alias() ||  $buddy->get_name();
-    system("growlnotify -t '$display_name ($who)' -m '$msg'");
+    $display_name =~ s/"/''/g;
+    system("growlnotify -t \"$display_name ($who)\" -m \"$msg\"");
     $_[2];
 }
 


### PR DESCRIPTION
A message or display name containing a single-quote character would produce unpredictable results at best.  I'm sure there's probably some better escaping mechanism but here's a really trivial solution in the meantime.
